### PR TITLE
🐛 SplitNetworkTransport conforming to updated NetworkTransport protocol.

### DIFF
--- a/Sources/ApolloWebSocket/SplitNetworkTransport.swift
+++ b/Sources/ApolloWebSocket/SplitNetworkTransport.swift
@@ -4,6 +4,7 @@ import Apollo
 
 
 public class SplitNetworkTransport: NetworkTransport {
+    
   private let httpNetworkTransport: NetworkTransport
   private let webSocketNetworkTransport: NetworkTransport
   
@@ -12,11 +13,11 @@ public class SplitNetworkTransport: NetworkTransport {
     self.webSocketNetworkTransport = webSocketNetworkTransport
   }
   
-  public func send<Operation>(operation: Operation, completionHandler: @escaping (GraphQLResponse<Operation>?, Error?) -> Void) -> Cancellable {
+    public func send<Operation>(operation: Operation, headers: [String : String]?, completionHandler: @escaping (GraphQLResponse<Operation>?, Error?) -> Void) -> Cancellable {
     if operation.operationType == .subscription {
-        return webSocketNetworkTransport.send(operation: operation, completionHandler: completionHandler)
+        return webSocketNetworkTransport.send(operation: operation, headers: headers, completionHandler: completionHandler)
     } else {
-        return httpNetworkTransport.send(operation: operation, completionHandler: completionHandler)
+        return httpNetworkTransport.send(operation: operation, headers: headers, completionHandler: completionHandler)
     }
   }
 }

--- a/Sources/ApolloWebSocket/WebSocketTransport.swift
+++ b/Sources/ApolloWebSocket/WebSocketTransport.swift
@@ -62,7 +62,7 @@ public class WebSocketTransport: NetworkTransport, WebSocketDelegate {
     self.websocket.connect()
   }
   
-  public func send<Operation>(operation: Operation, completionHandler: @escaping (_ response: GraphQLResponse<Operation>?, _ error: Error?) -> Void) -> Cancellable {
+    public func send<Operation>(operation: Operation, headers: [String : String]?, completionHandler: @escaping (_ response: GraphQLResponse<Operation>?, _ error: Error?) -> Void) -> Cancellable {
     if let error = self.error {
       completionHandler(nil,error)
       return EmptyCancellable()
@@ -76,7 +76,6 @@ public class WebSocketTransport: NetworkTransport, WebSocketDelegate {
         completionHandler(nil,error)
       }
     }
-    
   }
   
   public func isConnected() -> Bool {


### PR DESCRIPTION
For subscription we needed to install the sub-spec **Apollo/WebSockets**. This meant the SplitNetworkTransport needed updating to match the NetworkTransport protocol I originally changed (for the ability to pass through headers). 

The headers aren't actually be used by the subscription, so I could have made an extension specifying a method without it, but since we're going to refactor this completely, I didn't bother with such details.